### PR TITLE
Fix: re is not imported.

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -38,6 +38,7 @@ import getopt
 import shlex
 import traceback
 import cStringIO
+import re
 
 
 try:


### PR DESCRIPTION
If re module is not import following error will occured.

```
poller-debug.log:error: uncaptured python exception, closing channel
<booster-nrpe.NRPEAsyncClient connected at 0x35d64d0> (<type
'exceptions.NameError'>:global name 're' is not defined
[/usr/lib/python2.6/asyncore.py|readwrite|103]
[/usr/lib/python2.6/asyncore.py|handle_read_event|428]
[/var/lib/shinken/modules/booster-nrpe/module.py|handle_read|266]
[/var/lib/shinken/modules/booster-nrpe/module.py|read|159])
```

In module.py line 159 re module is call in order to remove some char after "\x00".I therefore think the re module should alway be imported. 

Regards
