### PR TITLE
Remove the trailing space in the module name, homepage and repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "booster-nrpe ",
+  "name": "booster-nrpe",
   "types": ["module"],
   "version": "1.4.2",
-  "homepage": "http://github.com/shinken-monitoring/mod-booster-nrpe ",
+  "homepage": "http://github.com/shinken-monitoring/mod-booster-nrpe",
   "author": "Jean Gabès",
   "description": "NRPE module to handle check_nrpe",
   "contributors": [
@@ -15,7 +15,7 @@
       "email": "magnus@appelquist.name"
     }
   ],
-  "repository": "https://github.com/shinken-monitoring/mod-booster-nrpe ",
+  "repository": "https://github.com/shinken-monitoring/mod-booster-nrpe",
   "keywords": [
     "module",
     "poller",


### PR DESCRIPTION
When we install using `--local` option, the package name is parsed from `package.json`. It's weird to see a folder that has a trailing space:

```
# ls /var/lib/shinken/modules/
auth-cfg-password/               dummy_broker_external/           __init__.py                      sqlitedb/
booster-nrpe /                   dummy_poller/                    nsca/                            syslog-sink/
dummy_arbiter/                   dummy_scheduler/                 pickle-retention-file-generic/   ui-graphite/
dummy_broker/                    graphite/                        pickle-retention-file-scheduler/ webui/
```
